### PR TITLE
volos-pgsql: unwrap results with a single result, if queried by ID

### DIFF
--- a/volos-pgsql/pgConnector.js
+++ b/volos-pgsql/pgConnector.js
@@ -224,9 +224,18 @@ var PgConnector = function (options) {
                 performQueryDfd.resolve(rows);
 
                 Q.allSettled(promises).then(function () {
-                    var wrappedResult = self.wrapResult(req, resp, rows, self.applicationName, {}, queryString);
+                    var result = rows;
+
+                    if (req.params.id) {
+                        if (rows.length === 1) {
+                            result = rows[0];
+                        } else if (!rows) {
+                            result = null;
+                        }
+                    }
+
+                    var wrappedResult = self.wrapResult(req, resp, result, self.applicationName, {}, queryString);
                     var responseString = JSON.stringify(wrappedResult, undefined, '\t');
-                    //resp.status(200).setHeader('Content-Type', 'application/json').send(responseString);
 
                     resp.writeHead(200, {'Content-Type': 'application/json'});
                     resp.end(responseString);


### PR DESCRIPTION
When requesting a single resource from a collection by ID, e.g. /collection/{id}, return the resource as-is in the `data` field instead of keeping it wrapped in an array (as if a collection of resources -- multiple rows -- is being returned)
